### PR TITLE
fix: read name and version from packageJson

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as packageInfo from '../package.json'
 import { initializeOpenTelemetry } from './main/core/instrumentation.js'
 import * as ResourceAttributes from './main/core/resource-attributes.js'
 
@@ -27,18 +28,13 @@ const config = {
   projectId: 'abecafa7681dfd65cc'
 }
 
-const packageJsonInfo = {
-  name: '@ibm/transistor-js',
-  version: '0.1.0'
-}
-
 const gitInfo = {
   remote: 'https://example.com/example-org/example-repo'
 }
 
 initializeOpenTelemetry({
-  [ResourceAttributes.EMITTER_NAME]: packageJsonInfo.name,
-  [ResourceAttributes.EMITTER_VERSION]: packageJsonInfo.version,
+  [ResourceAttributes.EMITTER_NAME]: packageInfo.default.name,
+  [ResourceAttributes.EMITTER_VERSION]: packageInfo.default.version,
   [ResourceAttributes.PROJECT_ID]: config.projectId,
   [ResourceAttributes.ANALYZED_RAW]: gitInfo.remote,
   [ResourceAttributes.ANALYZED_HOST]: 'example.com',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,7 @@
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 


### PR DESCRIPTION
Closes #

#### Changelog

**Changed**

- use name & version from package.json instead of mock data
- set `resolveJsonModule` to true in tsconfig.json

TODO: running into this error , might need a separate tsconfig.json for the project root? 
<img width="933" alt="image" src="https://github.com/carbon-design-system/transistor-js/assets/40550942/c6a1471a-0fe4-4fd9-b431-94883fee5879">
