### PR TITLE
feat: implement commit hash collection

### DIFF
--- a/src/main/core/anonymize/hash.ts
+++ b/src/main/core/anonymize/hash.ts
@@ -7,30 +7,47 @@
 import { createHash } from 'crypto'
 
 /**
- * Anonymizes incoming raw data. The keys to be anonymized are specified in the config object
- * under either the `hash` key or the `substitute` key.
+ * Does the following for each value in the provided `raw` object:
+ * - If the value is a string and its corresponding key is in the `keys` array, hash it.
+ * - If the value is an array containing strings and its corresponding key is in the `keys` array,
+ *   hash all of the strings in the array.
+ * - Otherwise, leave the value alone.
  *
- * @param raw - The attributes to anonymize.
+ * @param raw - The object to consider for hashing/de-identifying.
  * @param keys - They keys to hash.
  * @returns The raw object with all specified keys replaced with de-identified versions of their
  * values.
  */
 export function hash<T extends Record<string, unknown>>(
   raw: T,
-  keys: [keyof typeof raw, ...Array<keyof typeof raw>]
+  keys: [keyof T, ...Array<keyof T>]
 ): T {
   const hashedEntries = Object.entries(raw).map(([key, value]) => {
+    if (!keys.includes(key)) {
+      return [key, value]
+    }
+
+    if (Array.isArray(value)) {
+      const hashedValues = value.map((val) => {
+        if (typeof val !== 'string') {
+          return val
+        }
+
+        const hash = createHash('sha256')
+        hash.update(val)
+        return hash.digest('hex')
+      })
+
+      return [key, hashedValues]
+    }
+
     if (typeof value !== 'string') {
       return [key, value]
     }
 
-    if (keys.includes(key)) {
-      const hash = createHash('sha256')
-      hash.update(value)
-      return [key, hash.digest('hex')]
-    }
-
-    return [key, value]
+    const hash = createHash('sha256')
+    hash.update(value)
+    return [key, hash.digest('hex')]
   })
 
   return Object.fromEntries(hashedEntries)

--- a/src/main/core/anonymize/substitute.ts
+++ b/src/main/core/anonymize/substitute.ts
@@ -22,7 +22,7 @@ export function substitute<T extends Record<string, unknown>>(
   raw: T,
   allowedKeys: Array<keyof T>,
   allowedValues: unknown[]
-): T {
+): { [Property in keyof T]: T[Property] extends object ? string : T[Property] } {
   const substitutedEntries = Object.entries(raw).map(([key, value]) => {
     // Key is not safe. Substitute key and value
     if (!allowedKeys.includes(key)) {

--- a/src/main/core/custom-resource-attributes.ts
+++ b/src/main/core/custom-resource-attributes.ts
@@ -24,5 +24,6 @@ export const CustomResourceAttributes = Object.freeze({
   ANALYZED_HOST: 'analyzed.host',
   ANALYZED_OWNER: 'analyzed.owner',
   ANALYZED_REPOSITORY: 'analyzed.repository',
-  ANALYZED_COMMIT: 'analyzed.commit'
+  ANALYZED_COMMIT: 'analyzed.commit',
+  ANALYZED_REFS: 'analyzed.refs'
 })

--- a/src/main/core/de-null.ts
+++ b/src/main/core/de-null.ts
@@ -14,8 +14,8 @@
  */
 export function deNull<T extends Record<string, unknown>>(
   obj: T
-): { [Property in keyof T]?: NonNullable<T[Property]> } {
-  return Object.entries(obj).reduce<ReturnType<typeof deNull<T>>>((prev, [key, val]) => {
+): Record<string, NonNullable<T[string]>> {
+  return Object.entries(obj).reduce((prev, [key, val]) => {
     if (val === null || val === undefined) {
       return prev
     }

--- a/src/main/core/get-commit-branches.ts
+++ b/src/main/core/get-commit-branches.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { type Logger } from './log/logger.js'
+import { runCommand } from './run-command.js'
+
+/**
+ * Finds and returns the list of branches that point to the HEAD commit.
+ *
+ * @param commitHash - The hash of the commit to obtain branches for.
+ * @param cwd - Current working directory to use as the basis for finding the branches. This
+ * is an absolute path.
+ * @param logger - Logger instance.
+ * @throws An exception if no usable branch data was obtained.
+ * @returns The list of branches that point to the head commit, as an array.
+ */
+export async function getCommitBranches(
+  commitHash: string,
+  cwd: string,
+  logger: Logger
+): Promise<string[]> {
+  const allBranches = (
+    await runCommand(
+      `git branch --points-at=${commitHash} --format='%(refname:short)'`,
+      logger,
+      { cwd },
+      true
+    )
+  ).stdout
+    .split(/\r?\n/g)
+    .filter((file) => file !== '')
+
+  return allBranches
+}

--- a/src/main/core/get-commit-tags.ts
+++ b/src/main/core/get-commit-tags.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { type Logger } from './log/logger.js'
+import { runCommand } from './run-command.js'
+
+/**
+ * Finds and returns the list of branches that point to the HEAD commit.
+ *
+ * @param commitHash - The hash of the commit to obtain tags for.
+ * @param cwd - Current working directory to use as the basis for finding the branches. This
+ * is an absolute path.
+ * @param logger - Logger instance.
+ * @throws An exception if no usable branch data was obtained.
+ * @returns The list of branches that point to the head commit, as an array.
+ */
+export async function getCommitTags(
+  commitHash: string,
+  cwd: string,
+  logger: Logger
+): Promise<string[]> {
+  const allTags = (
+    await runCommand(
+      `git tag --points-at=${commitHash} --format='%(refname:short)'`,
+      logger,
+      { cwd },
+      true
+    )
+  ).stdout
+    .split(/\r?\n/g)
+    .filter((file) => file !== '')
+
+  return allTags
+}

--- a/src/main/ibm-telemetry.ts
+++ b/src/main/ibm-telemetry.ts
@@ -92,6 +92,7 @@ export class IbmTelemetry {
 
     // TODO: handle non-existent remote
     const gitOrigin = await runCommand('git remote get-url origin', this.logger)
+    const commitHash = await runCommand('git rev-parse HEAD', this.logger)
     const repository = tokenizeRepository(gitOrigin.stdout)
     const emitterInfo = await getTelemetryPackageData(this.logger)
 
@@ -105,7 +106,7 @@ export class IbmTelemetry {
           [CustomResourceAttributes.ANALYZED_HOST]: repository.host,
           [CustomResourceAttributes.ANALYZED_OWNER]: repository.owner,
           [CustomResourceAttributes.ANALYZED_REPOSITORY]: repository.repository,
-          [CustomResourceAttributes.ANALYZED_COMMIT]: 'abc123', // TODO: implement this!
+          [CustomResourceAttributes.ANALYZED_COMMIT]: commitHash.stdout,
           [CustomResourceAttributes.DATE]: date
         },
         [

--- a/src/test/core/anonymize/hash.test.ts
+++ b/src/test/core/anonymize/hash.test.ts
@@ -24,6 +24,23 @@ describe('anonymize', () => {
     })
   })
 
+  it('hashes an array value when its key is provided', () => {
+    const result = hash({ ignoreMe: 'i better not be hashed!', arrayValue: ['1', '2', '3', '4'] }, [
+      'arrayValue'
+    ])
+
+    expect(result).toMatchObject({
+      ignoreMe: 'i better not be hashed!',
+      // This is the sha256 hash of each element in the array
+      arrayValue: [
+        '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b',
+        'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35',
+        '4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce',
+        '4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a'
+      ]
+    })
+  })
+
   it('does not modify a number value', () => {
     const result = hash({ dollars: 999 }, ['dollars'])
 

--- a/src/test/scopes/jsx/metrics/element-metric.test.ts
+++ b/src/test/scopes/jsx/metrics/element-metric.test.ts
@@ -9,7 +9,11 @@ import { describe, expect, it } from 'vitest'
 
 import { hash } from '../../../../main/core/anonymize/hash.js'
 import { substitute } from '../../../../main/core/anonymize/substitute.js'
-import { type JsxElement, type JsxImport } from '../../../../main/scopes/jsx/interfaces.js'
+import {
+  type JsxElement,
+  JsxElementAttribute,
+  type JsxImport
+} from '../../../../main/scopes/jsx/interfaces.js'
 import { JsxScopeAttributes } from '../../../../main/scopes/jsx/jsx-scope-attributes.js'
 import { ElementMetric } from '../../../../main/scopes/jsx/metrics/element-metric.js'
 import { initLogger } from '../../../__utils/init-logger.js'
@@ -50,9 +54,12 @@ describe('class: ElementMetric', () => {
   it('returns the correct attributes for a standard element', () => {
     const attributes = new ElementMetric(jsxElement, jsxImport, 'the-library', config, logger)
       .attributes
-    const attrMap = jsxElement.attributes.reduce<Record<string, unknown>>((prev, cur) => {
-      return { ...prev, [cur.name]: cur.value }
-    }, {})
+    const attrMap = jsxElement.attributes.reduce<Record<string, JsxElementAttribute['value']>>(
+      (prev, cur) => {
+        return { ...prev, [cur.name]: cur.value }
+      },
+      {}
+    )
 
     const subs = substitute(attrMap, [], [])
 


### PR DESCRIPTION
Closes #106 

Adds commit hash and ref (branches + tags) to telemetry collection resources

#### Changelog

**New**

- Added `'analyzed.commit'` and `'analyzed.refs'` to telemetry resources.
- new `getCommitBranches` and `getCommitTags` functions
- Test case to test new `hash` functionality
 
**Changed**

- Updated `hash` util to be able to handle arrays
- Type enhancements to `deNull` and `substitute` functions
- offload git-related get functions `getGitInfo` in src/main/ibm-telemetry.ts
- Type correction in ElementMetric test

#### Testing / reviewing
