### PR TITLE
feat: add command line telemetry disclosure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@ibm/telemetry-js",
       "version": "1.5.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      },
       "bin": {
         "ibmtelemetry": "dist/collect.js"
       },
@@ -384,18 +387,6 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/format/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@commitlint/is-ignored": {
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.2.2.tgz",
@@ -443,18 +434,6 @@
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@commitlint/message": {
@@ -644,18 +623,6 @@
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -2489,16 +2456,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -3578,6 +3540,22 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -4977,18 +4955,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "files": [
     "dist/background-process.js",
     "dist/collect.js",
-    "dist/spawn-background-process.js"
+    "dist/spawn-background-process.js",
+    "scripts/postinstall.js"
   ],
   "scripts": {
     "build": "npm run clean && npm run compile && npm run compile:collect && npm run bundle",
@@ -44,6 +45,9 @@
     "prepare": "husky",
     "test": "vitest run --coverage",
     "test:watch": "vitest --coverage"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict'
+import chalk from 'chalk'
+
+console.warn(
+  '----------------------------------------------------------------------------' +
+    '-----------------------------------------------------------------------\n' +
+    chalk.yellow('NOTICE: ') +
+    'A package you installed uses IBM Telemetry to collect metrics data. ' +
+    'By installing this package as a dependency you are agreeing to telemetry collection.\n\nTo opt out, see ' +
+    chalk.blue.underline.italic(
+      'https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection'
+    ) +
+    '.\n\nFor more information on the data being collected, please refer to the IBM Telemetry documentation at ' +
+    chalk.blue.underline.italic(
+      'https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics.\n'
+    ) +
+    '-----------------------------------------------------------------------------' +
+    '----------------------------------------------------------------------\n'
+)


### PR DESCRIPTION
Closes #233 
{{ Short description }}

#### Changelog

**New**

- Adds postinstall script to `package.json`
- Adds `chalk` dependency
- Adds telemetry collection notice as a console warn through the [`postinstall`](scripts/postinstall.js) script

#### Testing / reviewing

- Ran script manually using `node scripts/postinstall.js`:
<img width="1274" alt="image" src="https://github.com/ibm-telemetry/telemetry-js/assets/40550942/a4ab3b4c-2306-4f76-bc16-e2c668597858">
- Used `npm publish --dry-run` to confirm postinstall script will be included in published package
<img width="859" alt="image" src="https://github.com/ibm-telemetry/telemetry-js/assets/40550942/ce64b160-8534-43a7-a511-e6ff9c733ad6">


