### PR TITLE
fix: refine js scope function parsing logic

### DIFF
--- a/src/main/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.ts
+++ b/src/main/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.ts
@@ -40,13 +40,13 @@ export class CallExpressionNodeHandler extends JsNodeHandler<JsFunction> {
     const argsLength = node.arguments.end - node.arguments.pos
     const nodeText = node.getText(this.sourceFile)
     // account for closing parentheses, remove newlines
-    const functionName = nodeText
-      .substring(0, nodeText.length - argsLength - 1)
-      .replace(/[\r\n]+/gm, '')
-      .trim()
+    let functionName = nodeText.substring(0, nodeText.length - argsLength - 1).replace(/\s/g, '')
+
+    functionName = functionName.substring(0, functionName.length - 1)
+
     const jsFunction: JsFunction = {
       // account for opening parentheses
-      name: functionName.substring(0, functionName.length - 1),
+      name: functionName,
       accessPath: [],
       arguments: [],
       startPos: node.pos,

--- a/src/main/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.ts
+++ b/src/main/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.ts
@@ -39,9 +39,14 @@ export class CallExpressionNodeHandler extends JsNodeHandler<JsFunction> {
   getData(node: ts.CallExpression): JsFunction {
     const argsLength = node.arguments.end - node.arguments.pos
     const nodeText = node.getText(this.sourceFile)
+    // account for closing parentheses, remove newlines
+    const functionName = nodeText
+      .substring(0, nodeText.length - argsLength - 1)
+      .replace(/[\r\n]+/gm, '')
+      .trim()
     const jsFunction: JsFunction = {
-      // account for parentheses
-      name: nodeText.substring(0, nodeText.length - argsLength - 2),
+      // account for opening parentheses
+      name: functionName.substring(0, functionName.length - 1),
       accessPath: [],
       arguments: [],
       startPos: node.pos,

--- a/src/test/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.test.ts
+++ b/src/test/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.test.ts
@@ -92,7 +92,7 @@ describe('class: CallExpressionExpressionNodeHandler', async () => {
     })
   })
 
-  it('??', () => {
+  it('captures nested functions', () => {
     const accumulator = new JsFunctionTokenAccumulator()
     const sourceFile = createSourceFileFromText('foo().faa()')
     const nodes = findNodesByType<ts.CallExpression>(sourceFile, ts.SyntaxKind.CallExpression)
@@ -130,6 +130,25 @@ describe('class: CallExpressionExpressionNodeHandler', async () => {
       expect(accumulator.functions[0]).toMatchObject({
         name: 'foo',
         arguments: [new ComplexValue('first')],
+        accessPath: ['foo']
+      })
+    })
+    it('correctly trims a multiline function and its arguments', () => {
+      const accumulator = new JsFunctionTokenAccumulator()
+      const sourceFile = createSourceFileFromText(`foo(
+        'first'
+      )`)
+      const nodes = findNodesByType<ts.CallExpression>(sourceFile, ts.SyntaxKind.CallExpression)
+      const handler = new CallExpressionNodeHandler(sourceFile, logger)
+
+      nodes.forEach((node) => {
+        handler.handle(node, accumulator)
+      })
+
+      expect(accumulator.functions).toHaveLength(1)
+      expect(accumulator.functions[0]).toMatchObject({
+        name: 'foo',
+        arguments: ['first'],
         accessPath: ['foo']
       })
     })

--- a/src/test/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.test.ts
+++ b/src/test/scopes/js/node-handlers/tokens-and-functions-handlers/call-expression-node-handler.test.ts
@@ -136,7 +136,7 @@ describe('class: CallExpressionExpressionNodeHandler', async () => {
     it('correctly trims a multiline function and its arguments', () => {
       const accumulator = new JsFunctionTokenAccumulator()
       const sourceFile = createSourceFileFromText(`foo(
-        'first'
+        'first second'
       )`)
       const nodes = findNodesByType<ts.CallExpression>(sourceFile, ts.SyntaxKind.CallExpression)
       const handler = new CallExpressionNodeHandler(sourceFile, logger)
@@ -148,7 +148,27 @@ describe('class: CallExpressionExpressionNodeHandler', async () => {
       expect(accumulator.functions).toHaveLength(1)
       expect(accumulator.functions[0]).toMatchObject({
         name: 'foo',
-        arguments: ['first'],
+        arguments: ['first second'],
+        accessPath: ['foo']
+      })
+    })
+    it('correctly trims a multiline function and its multiline arguments', () => {
+      const accumulator = new JsFunctionTokenAccumulator()
+      const sourceFile = createSourceFileFromText(`foo(
+        'first second',
+        5
+      )`)
+      const nodes = findNodesByType<ts.CallExpression>(sourceFile, ts.SyntaxKind.CallExpression)
+      const handler = new CallExpressionNodeHandler(sourceFile, logger)
+
+      nodes.forEach((node) => {
+        handler.handle(node, accumulator)
+      })
+
+      expect(accumulator.functions).toHaveLength(1)
+      expect(accumulator.functions[0]).toMatchObject({
+        name: 'foo',
+        arguments: ['first second', 5],
         accessPath: ['foo']
       })
     })


### PR DESCRIPTION
Closes #237 

Fixes JS scope bug where some functions names where including extra spacing or parentheses. This happened with functions that spanned across multiple lines/tabs due to the extra spacing.

#### Changelog

**New**

- Added multiline function test for `CallExpressionNodeHandler`

**Changed**

- Trim function names before capturing

#### Testing / reviewing

All unit tests should pass and code should be human-readable