### PR TITLE
fix: prevent terminal popup on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,20 @@ During a build or any other CI operation that installs package dependencies (`np
 
 IBM Telemetry will collect metric data for instrumented packages by default. If your project is
 installing an IBM Telemetry-instrumented package and you want to opt-out of metric collection, set
-an environment variable of `IBM_TELEMETRY_DISABLED='true'`. This will prevent **any and all** data
-from being collected in your project.
+the following environment variable to prevent **any and all** data from being collected in your
+project.
+
+#### Unix, Linux, MacOS, BSD, etc.
+
+```sh
+IBM_TELEMETRY_DISABLED='true'
+```
+
+#### Windows (powershell)
+
+```powershell
+$Env:IBM_TELEMETRY_DISABLED='true'
+```
 
 ### Anonymizing / de-identifying
 

--- a/src/main/spawn-background-process.ts
+++ b/src/main/spawn-background-process.ts
@@ -1,3 +1,5 @@
+import { Environment } from './core/environment.js'
+
 /*
  * Copyright IBM Corp. 2024, 2024
  *
@@ -8,11 +10,15 @@ async function spawnBackgroundProcess() {
   const childProcess = await import('node:child_process')
   const path = await import('node:path')
   const { fileURLToPath } = await import('node:url')
-
   const { createLogFilePath } = await import('./core/log/create-log-file-path.js')
-
   const date = new Date().toISOString()
   const logFilePath = createLogFilePath(date)
+  const environment = new Environment()
+
+  if (environment.isCI === false || environment.isTelemetryEnabled === false) {
+    // Do nothing and exit quietly
+    return
+  }
 
   console.log('Log file:', logFilePath)
 
@@ -27,7 +33,7 @@ async function spawnBackgroundProcess() {
       {
         stdio: 'ignore',
         detached: true,
-        shell: true
+        shell: false
       }
     )
     .unref()


### PR DESCRIPTION
Fixes #250

- Earlier checking of opt-out environment variables
- Better guidance for opting out for Windows users
- Removal of background process's spawned shell window