### PR TITLE
fix: handle canary npm tag in cdn links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@ibm/telemetry-js",
       "version": "1.10.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "htmlparser2": "^10.0.0"
-      },
       "bin": {
         "ibmtelemetry": "dist/collect.js"
       },
@@ -47,6 +44,7 @@
         "eslint-plugin-promise": "^6.6.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "globals": "^15.9.0",
+        "htmlparser2": "^10.0.0",
         "husky": "^9.1.5",
         "js-yaml": "^4.1.0",
         "lint-staged": "^15.2.10",
@@ -3477,6 +3475,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -3491,6 +3490,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3503,6 +3503,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3515,6 +3516,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -3530,6 +3532,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -3568,6 +3571,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -5004,6 +5008,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
       "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
     "test": "vitest run --coverage",
     "test:watch": "vitest --coverage"
   },
-  "dependencies": {
-    "htmlparser2": "^10.0.0"
-  },
   "devDependencies": {
     "@commitlint/cli": "^19.4.1",
     "@commitlint/config-conventional": "^19.4.1",
@@ -82,6 +79,7 @@
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^15.9.0",
+    "htmlparser2": "^10.0.0",
     "husky": "^9.1.5",
     "js-yaml": "^4.1.0",
     "lint-staged": "^15.2.10",

--- a/src/main/scopes/wc/metrics/element-metric.ts
+++ b/src/main/scopes/wc/metrics/element-metric.ts
@@ -22,7 +22,7 @@ import type { CdnImport } from '../interfaces.js'
 import { type WcElement, type WcElementAttribute } from '../interfaces.js'
 import { isCdnImport } from '../utils/is-cdn-import.js'
 import { isJsxElement } from '../utils/is-jsx-element.js'
-import { WC_PACKAGE_REACT_WRAPPERS } from '../wc-defs.js'
+import { CDN_NPM_TAGS, WC_PACKAGE_REACT_WRAPPERS } from '../wc-defs.js'
 
 /**
  * Wc scope metric that generates a wc.element individual metric for a given element.
@@ -113,16 +113,18 @@ export class ElementMetric extends ScopeMetric {
       metricData[WcScopeAttributes.IMPORT_SOURCE] = 'cdn'
       metricData[WcScopeAttributes.MODULE_SPECIFIER] = this.matchingImport.package
       const importTag = this.matchingImport.version.split('/')[1]
-      if (importTag === 'latest' || importTag === 'next') {
+      if (importTag !== undefined && CDN_NPM_TAGS.includes(importTag)) {
         metricData[NpmScopeAttributes.INSTRUMENTED_VERSION_RAW] = this.matchingImport.version
         hashVersionRaw = false
       } else {
         // CDN import expected to specify version
-        const parsedVersion = this.matchingImport.version.split('v')[1]?.split('.') ?? []
+        const [version, preRelease] = this.matchingImport.version.split('v')[1]?.split('-') ?? []
+        const parsedVersion = version?.split('.') ?? []
         metricData[NpmScopeAttributes.INSTRUMENTED_VERSION_RAW] = parsedVersion.join('.')
         metricData[NpmScopeAttributes.INSTRUMENTED_VERSION_MAJOR] = parsedVersion[0]
         metricData[NpmScopeAttributes.INSTRUMENTED_VERSION_MINOR] = parsedVersion[1]
         metricData[NpmScopeAttributes.INSTRUMENTED_VERSION_PATCH] = parsedVersion[2]
+        metricData[NpmScopeAttributes.INSTRUMENTED_VERSION_PRE_RELEASE] = preRelease
       }
     } else {
       // add fields specific to npm imports

--- a/src/main/scopes/wc/wc-defs.ts
+++ b/src/main/scopes/wc/wc-defs.ts
@@ -24,6 +24,8 @@ export const CDN_DOMAINS = ['1.www.s81c.com']
 
 export const CDN_ENDING = '.min.js'
 
+export const CDN_NPM_TAGS = ['canary', 'latest', 'next']
+
 export const CDN_PACKAGES = new Map([
   [WC_PACKAGES.CARBON_WC, '/carbon/web-components/'],
   [WC_PACKAGES.CARBON_DOT_COM_WC, '/carbon-for-ibm-dotcom/']


### PR DESCRIPTION
These changes account for the `canary` tag being used within a CDN import link when the Emitter generates an element metric.

#### Changelog

**New**
- Created array in `wc-defs.ts` that holds all valid npm tags used in CDN links and include `canary`
- Parse out a pre-release version from a CDN link (e.g. `rc.0` from `v1.0.0-rc.0`) and store in `npm.dependency.version.preRelease`

**Changed**
- Updated logic in `element-metric.ts` to check if any tag in `CDN_NPM_TAGS` matches the tag parsed from the given CDN link
- Moved `htmlparser2` from `dependencies` to `devDependencies`

#### Testing / reviewing

- Test Emitter and Collector locally on repo(s) containing CDN imports
